### PR TITLE
Fix typo in the README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import dynamicImportPolyfill from 'dynamic-import-polyfill';
 // This needs to be done before any dynamic imports are used.
 dynamicImportPolyfill.initialize({
   modulePath: '/public', // Defaults to '.'
-  importFunctionName = '$$import' // Defaults to '__import__'
+  importFunctionName: '$$import' // Defaults to '__import__'
 });
 ````
 


### PR DESCRIPTION
This PR fixes a tiny typo in the code example in the README